### PR TITLE
Make compatible with Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # chat-example
 
-This is the source code for a very simple chat example used for 
-the [Getting Started](http://socket.io/get-started/chat/) guide 
+This is the source code for a very simple chat example used for
+the [Getting Started](http://socket.io/get-started/chat/) guide
 of the Socket.IO website.
 
 Please refer to it to learn how to run this application.
+
+You can also spin up a free Heroku dyno to test it out:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/guille/chat-example)

--- a/app.json
+++ b/app.json
@@ -1,0 +1,22 @@
+{
+  "name": "Socket-Chat-Example",
+  "description": "my first socket.io app",
+  "website": "https://github.com/guille/chat-example",
+  "repository": "https://github.com/guille/chat-example",
+  "logo": "https://node-js-sample.herokuapp.com/node.svg",
+  "success_url": "/",
+  "keywords": [
+    "node",
+    "express",
+    "socket.io",
+    "realtime",
+    "websocket"
+  ],
+  "scripts": {
+  },
+  "addons": [
+  ],
+  "env": {
+    "BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-nodejs"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -12,6 +12,6 @@ io.on('connection', function(socket){
   });
 });
 
-http.listen(3000, function(){
-  console.log('listening on *:3000');
+http.listen(process.env.PORT || 3000, function(){
+  console.log('listening on *:' + http.address().port);
 });

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "express": "4.3.1",
     "socket.io": "1.0.2"
+  },
+  "scripts": {
+    "start": "node index.js"
   }
 }


### PR DESCRIPTION
We get several tickets from users who have trouble deploying these socket.io demos because of small pieces (no npm start, hardcoded port, etc). This makes it easier to get up and running:
- made `npm start` work
- using port 3000 as default if no `PORT` var is specified
- added app.json file for deploy button
- added deploy button to bottom of readme
